### PR TITLE
github pages の deploy に関する修正

### DIFF
--- a/.github/workflows/collect.yaml
+++ b/.github/workflows/collect.yaml
@@ -88,6 +88,9 @@ jobs:
       - run: npm run build
         working-directory: evidence
 
+      - run: chmod -R go+r build
+        working-directory: evidence
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -107,4 +110,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          timeout: 1800000
+          timeout: 600000


### PR DESCRIPTION
- 600 で read permission の無い場合のエラー回避
- timeout が上限を超えているのを修正