### PR TITLE
master に push されたら evidence の deploy を実行

### DIFF
--- a/.github/workflows/deploy-evidence.yaml
+++ b/.github/workflows/deploy-evidence.yaml
@@ -3,8 +3,9 @@ name: deploy evidence
 on:
   workflow_dispatch:
   pull_request:
-  schedule:
-    - cron: '40 0/6 * * *'
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
schedule 実行は不要なので削除